### PR TITLE
Toc

### DIFF
--- a/client/pmpm.css
+++ b/client/pmpm.css
@@ -505,8 +505,3 @@ h2#toc-title {
 .toc-toggle {
     text-align: center;
 }
-
-.toc-missing {
-    color: #898887;
-    font-style: italic;
-}

--- a/client/pmpm.css
+++ b/client/pmpm.css
@@ -476,8 +476,8 @@ div#status {
 
 #TOC.open {
     opacity: 1;
-    padding-left: 1.5em;
-    padding-right: 1.5em;
+    padding-left: 1.8em;
+    padding-right: 1.8em;
 }
 
 h2#toc-title {
@@ -492,23 +492,14 @@ h2#toc-title {
     font-weight: bold;
 }
 
-#TOC ol {
-    counter-reset: item;
+#TOC ul {
     margin: 0;
     padding: 0;
+    list-style: disc;
 }
 
-#TOC ol > li {
-    counter-increment: item;
-    display: block;
-}
-
-#TOC ol ol > li {
-    padding-left: 1.1em;
-}
-
-#TOC ol > li:before {
-    content: counters(item, ".") ". ";
+#TOC ul ul {
+    margin-left: 1.1em;
 }
 
 .toc-toggle {

--- a/client/pmpm.css
+++ b/client/pmpm.css
@@ -409,7 +409,12 @@ table td {
 @media screen {
   body {
     margin-bottom: 80%;
+    max-width: none;
+  }
+
+  .markdown-body {
     max-width: 44em;
+    margin: 0px auto;
   }
 }
 code, pre, .sourceCode {
@@ -455,4 +460,54 @@ div#status {
 /* Not found citations, only pandoc version < 2.11 */
 .citeproc-not-found {
     color: #ad0625;
+}
+
+/* table of contents */
+#toc {
+    float: right;
+    margin-left: 1em;
+
+    border: solid 1px black;
+
+    opacity: .5;
+    padding-right: .5em;
+    padding-left: .5em;
+}
+
+#toc.open {
+    opacity: 1;
+    padding-left: 1.5em;
+    padding-right: 1.5em;
+}
+
+#toc ol {
+    counter-reset: item;
+    padding-left: 1em;
+    margin-top: 0em;
+    margin-bottom: 0em;
+}
+
+#toc ol > li {
+    counter-increment: item;
+}
+
+#toc ol ol > li {
+    display: block;
+}
+
+#toc ol ol > li:before {
+    content: counters(item, ".") ". ";
+}
+
+.toc-toggle {
+    text-align: center;
+}
+
+#toc.open #toc-toggle {
+    font-weight: bold;
+}
+
+.toc-missing {
+    color: #898887;
+    font-style: italic;
 }

--- a/client/pmpm.css
+++ b/client/pmpm.css
@@ -503,7 +503,7 @@ div#status {
     text-align: center;
 }
 
-#toc.open #toc-toggle {
+#toc.open .toc-toggle {
     font-weight: bold;
 }
 

--- a/client/pmpm.css
+++ b/client/pmpm.css
@@ -493,20 +493,20 @@ h2#toc-title {
 
 #TOC ol {
     counter-reset: item;
-    padding-left: 1em;
-    margin-top: 0em;
-    margin-bottom: 0em;
+    margin: 0;
+    padding: 0;
 }
 
 #TOC ol > li {
     counter-increment: item;
-}
-
-#TOC ol ol > li {
     display: block;
 }
 
-#TOC ol ol > li:before {
+#TOC ol ol > li {
+    padding-left: 1.1em;
+}
+
+#TOC ol > li:before {
     content: counters(item, ".") ". ";
 }
 

--- a/client/pmpm.css
+++ b/client/pmpm.css
@@ -485,6 +485,7 @@ h2#toc-title {
     margin-bottom: 0;
     font-size: 1em;
     line-height: inherit;
+    cursor: pointer;
 }
 
 #TOC.open h2#toc-title {

--- a/client/pmpm.css
+++ b/client/pmpm.css
@@ -463,7 +463,7 @@ div#status {
 }
 
 /* table of contents */
-#toc {
+#TOC {
     float: right;
     margin-left: 1em;
 
@@ -474,37 +474,44 @@ div#status {
     padding-left: .5em;
 }
 
-#toc.open {
+#TOC.open {
     opacity: 1;
     padding-left: 1.5em;
     padding-right: 1.5em;
 }
 
-#toc ol {
+h2#toc-title {
+    margin-top: 0;
+    margin-bottom: 0;
+    font-size: 1em;
+    line-height: inherit;
+}
+
+#TOC.open h2#toc-title {
+    font-weight: bold;
+}
+
+#TOC ol {
     counter-reset: item;
     padding-left: 1em;
     margin-top: 0em;
     margin-bottom: 0em;
 }
 
-#toc ol > li {
+#TOC ol > li {
     counter-increment: item;
 }
 
-#toc ol ol > li {
+#TOC ol ol > li {
     display: block;
 }
 
-#toc ol ol > li:before {
+#TOC ol ol > li:before {
     content: counters(item, ".") ". ";
 }
 
 .toc-toggle {
     text-align: center;
-}
-
-#toc.open .toc-toggle {
-    font-weight: bold;
 }
 
 .toc-missing {

--- a/client/pmpm.html
+++ b/client/pmpm.html
@@ -14,7 +14,7 @@
 
 <nav id="TOC" role="doc-toc" style="display: none;">
     <h2 id="toc-title" class="toc-toggle"><a href="#">Contents</a></h2>
-    <ol id="toc-content" style="display: none;"></ol>
+    <ul id="toc-content" style="display: none;"></ul>
 </nav>
 
 <div class="markdown-body">

--- a/client/pmpm.html
+++ b/client/pmpm.html
@@ -12,6 +12,11 @@
 
 <div id="status"></div>
 
+<div id="toc">
+    <div class="toc-toggle"><a href="#">Contents</a></div>
+    <ol id="toc-content" style="display: none;"></ol>
+</div>
+
 <div class="markdown-body">
     <div id="content"></div>
     <div id="references">

--- a/client/pmpm.html
+++ b/client/pmpm.html
@@ -12,10 +12,10 @@
 
 <div id="status"></div>
 
-<div id="toc">
-    <div class="toc-toggle"><a href="#">Contents</a></div>
+<nav id="TOC" role="doc-toc" style="display: none;">
+    <h2 id="toc-title" class="toc-toggle"><a href="#">Contents</a></h2>
     <ol id="toc-content" style="display: none;"></ol>
-</div>
+</nav>
 
 <div class="markdown-body">
     <div id="content"></div>

--- a/client/pmpm.js
+++ b/client/pmpm.js
@@ -877,7 +877,7 @@ function init(customWrappingTagName, customFpathLoadMessagePrefix)
     initWebsocket();
 
     // Table of content toggle
-    // Is ignored if no <div id="toc"> exists (e.g. revelajs)
+    // Is ignored if no <div id="toc"> exists (e.g. revealjs)
     tocContainer?.getElementsByClassName('toc-toggle')[0]?.addEventListener('click', (ev) => {
         toggleToc();
         ev.preventDefault();

--- a/client/pmpm.js
+++ b/client/pmpm.js
@@ -143,11 +143,9 @@ function updateToc()
         // cloneNode so that math works also in toc
         for(const el of h.childNodes)
             a.appendChild(el.cloneNode(true));
-        // Abuse footnote link mechanism
-        // TODO: Make this generic
         a.href = '#';
-        a._footnoteHref = h;
-        a.onclick = footnoteClickEvent;
+        a._pmpmNodeLink = h;
+        a.onclick = nodeLinkClickEvent;
 
         const li = document.createElement('li');
         li.appendChild(a);
@@ -340,7 +338,7 @@ function localLinkClickEvent(el)
     return false;
 }
 
-function footnoteClickEvent(event)
+function nodeLinkClickEvent(event)
 {
     let a = event.target;
     while(a && a.tagName != 'A')
@@ -350,7 +348,7 @@ function footnoteClickEvent(event)
 
     // Push state so browser back button jumps to previous position
     history.pushState(history.state, fpath);
-    window.scrollTo({top: a._footnoteHref.getBoundingClientRect().top + window.pageYOffset});
+    window.scrollTo({top: a._pmpmNodeLink.getBoundingClientRect().top + window.pageYOffset});
     return false;
 }
 
@@ -387,12 +385,12 @@ function extractFootnotes(newEl, newFn)
             if(aback.getAttribute('href') == '#fnref'+num) {
                 const aref = document.getElementById('fnref'+num);
                 aref.removeAttribute('id'); // not unique
-                aref._footnoteHref = aback;
-                aref.onclick = footnoteClickEvent;
+                aref._pmpmNodeLink = aback;
+                aref.onclick = nodeLinkClickEvent;
 
                 li._footnoteAref = aref;
-                aback._footnoteHref = aref;
-                aback.onclick = footnoteClickEvent;
+                aback._pmpmNodeLink = aref;
+                aback.onclick = nodeLinkClickEvent;
 
                 break; // Should only be one such link
             }

--- a/client/pmpm.js
+++ b/client/pmpm.js
@@ -84,7 +84,9 @@ function updateToc()
 
     // Build toc based on headings
     // Use container.parentNode because this also includes references
-    const hs = container.parentNode.querySelectorAll('h1, h2, h3, h4, h5, h6');
+    // Like pandoc's default 'toc-depth: 3'. Not configurable at the moment since
+    // pandoc doesn't parse 'toc-depth' from YAML metadata block
+    const hs = container.parentNode.querySelectorAll('h1, h2, h3');
     const uls = [tocContent];
     tocContent._pmpmLastHlevel = 1;
     let lastLi = undefined;

--- a/client/pmpm.js
+++ b/client/pmpm.js
@@ -70,7 +70,10 @@ async function getKatex() {
 // Table of contents
 const tocContainer = document.getElementById('TOC');
 const tocContent = document.getElementById('toc-content');
+const tocTitle = document.getElementById('toc-title');
+const tocTitleTextDefault = tocTitle?.textContent;
 let tocEnabled = false;
+let tocTitleText;
 let tocUpdated = false;
 let tocContentVisible = false;
 
@@ -723,6 +726,10 @@ function updateBodyFromBlocks(contentnew, referenceSectionTitle)
             updateToc();
     }
 
+    // Set toc title
+    if(tocEnabled)
+        tocTitle.textContent = tocTitleText;
+
     // Set references title
     if(referenceSectionTitle !== "") {
         referencesTitle.textContent = referenceSectionTitle;
@@ -796,6 +803,7 @@ async function initWebsocket()
         if(message.htmlblocks !== undefined) {
             // update page
             tocEnabled = message.toc;
+            tocTitleText = message["toc-title"] ?? tocTitleTextDefault;
             contentBibid = message.bibid;
             suppressBibliography = message["suppress-bibliography"];
             updateBodyFromBlocks(message.htmlblocks, message["reference-section-title"]);

--- a/client/pmpm.js
+++ b/client/pmpm.js
@@ -106,7 +106,7 @@ function updateToc()
         const lastHLevel = uls[uls.length-1]._pmpmLastHlevel;
 
         let ul;
-        if(hLevel > lastHLevel) {
+        if(hLevel > lastHLevel && lastLi) {
             // Jump at most one level up, even if one level was left out
             // e.g. "# one\n### three"
             ul = document.createElement('ul');

--- a/client/pmpm.js
+++ b/client/pmpm.js
@@ -68,7 +68,7 @@ async function getKatex() {
 }
 
 // Table of contents
-const tocContainer = document.getElementById('toc');
+const tocContainer = document.getElementById('TOC');
 const tocContent = document.getElementById('toc-content');
 let tocEnabled = false;
 let tocUpdated = false;

--- a/client/pmpm.js
+++ b/client/pmpm.js
@@ -696,17 +696,19 @@ function updateBodyFromBlocks(contentnew, referenceSectionTitle)
     const blockRenderingPromise = Promise.all(renderPromises);
 
     if(firstChange !== undefined) {
-        // Update table of contents if toc is currently visible or mark as
-        // to-be-updated when it becomes visible next time
-        if(tocVisible)
-            updateToc();
-        else
-            tocUpdated = false;
-
-        // scroll (first changed child of) first changed block into view
-        // But only after rendering is finished. Otherwise the first change detection
-        // may find a still-rendering but unchanged element.
         blockRenderingPromise.finally(() => {
+            // Update table of contents if toc is currently visible or mark as
+            // to-be-updated when it becomes visible next time
+            // But only after rendering is finished. Otherwise katex in headings may not
+            // be rendered yet and cannot be copied to toc.
+            if(tocVisible)
+                updateToc();
+            else
+                tocUpdated = false;
+
+            // scroll (first changed child of) first changed block into view
+            // But only after rendering is finished. Otherwise the first change detection
+            // may find a still-rendering but unchanged element.
             scrollToFirstChange(firstChange, firstChangeCompare);
         });
     }

--- a/client/pmpm.js
+++ b/client/pmpm.js
@@ -85,7 +85,7 @@ function updateToc()
     // Build toc based on headings
     // Use container.parentNode because this also includes references
     const hs = container.parentNode.querySelectorAll('h1, h2, h3, h4, h5, h6');
-    const ols = [tocContent];
+    const uls = [tocContent];
     let lastLi = undefined;
     for(const h of hs) {
 
@@ -101,18 +101,18 @@ function updateToc()
                 continue;
         }
 
-        const lastLevel = ols.length;
+        const lastLevel = uls.length;
 
-        let ol;
+        let ul;
         if(level > lastLevel) {
-            ol = ols[lastLevel-1];
+            ul = uls[lastLevel-1];
             let tmp = lastLevel;
 
             // First try to level-up inside last-added <li>
             if(lastLi !== undefined) {
-                ol = document.createElement('ol');
-                lastLi.appendChild(ol);
-                ols.push(ol);
+                ul = document.createElement('ul');
+                lastLi.appendChild(ul);
+                uls.push(ul);
                 tmp++;
             }
 
@@ -124,23 +124,23 @@ function updateToc()
                 span.textContent = 'missing';
                 const li = document.createElement('li');
                 li.appendChild(span);
-                ol.appendChild(li);
+                ul.appendChild(li);
 
-                ol = document.createElement('ol');
-                li.appendChild(ol);
-                ols.push(ol);
+                ul = document.createElement('ul');
+                li.appendChild(ul);
+                uls.push(ul);
                 tmp++;
             }
 
         } else if(level < lastLevel) {
             let tmp = lastLevel;
             while(tmp > level) {
-                ols.pop();
+                uls.pop();
                 tmp--;
             }
-            ol = ols[ols.length-1];
+            ul = uls[uls.length-1];
         } else {
-            ol = ols[lastLevel-1];
+            ul = uls[lastLevel-1];
         }
 
         const a = document.createElement('a');
@@ -154,7 +154,7 @@ function updateToc()
         const li = document.createElement('li');
         li.appendChild(a);
 
-        ol.appendChild(li);
+        ul.appendChild(li);
 
         lastLi = li;
     }

--- a/pmpm/websocket.py
+++ b/pmpm/websocket.py
@@ -314,14 +314,15 @@ async def new_filepath_request(fpath, revealjs):
 
 
 async def process_new_content(fpath, content):
-    htmlblocks, supbib, refsectit, bibid = await md2htmlblocks(content,
-                                                               fpath.parent)
+    htmlblocks, supbib, refsectit, bibid, toc = await md2htmlblocks(
+        content, fpath.parent)
     message = {
         "filepath": str(fpath.relative_to(ARGS.home)),
         "htmlblocks": htmlblocks,
         "suppress-bibliography": supbib,
         "reference-section-title": refsectit,
         "bibid": bibid,
+        "toc": toc
         }
     EVENT_LOOP.create_task(send_message_to_all_js_clients(message))
 
@@ -623,7 +624,13 @@ async def md2htmlblocks(content, cwd):
     except (IndexError, KeyError):
         refsectit = ''
 
+    try:
+        toc = jsonout['meta']['toc']['c'] is True
+    except KeyError:
+        toc = False
+
     return (titleblock + htmlblocks,
             supbib,
             refsectit,
-            bibid)
+            bibid,
+            toc)

--- a/pmpm/websocket.py
+++ b/pmpm/websocket.py
@@ -314,7 +314,7 @@ async def new_filepath_request(fpath, revealjs):
 
 
 async def process_new_content(fpath, content):
-    htmlblocks, supbib, refsectit, bibid, toc = await md2htmlblocks(
+    htmlblocks, supbib, refsectit, bibid, toc, toctitle = await md2htmlblocks(
         content, fpath.parent)
     message = {
         "filepath": str(fpath.relative_to(ARGS.home)),
@@ -322,7 +322,8 @@ async def process_new_content(fpath, content):
         "suppress-bibliography": supbib,
         "reference-section-title": refsectit,
         "bibid": bibid,
-        "toc": toc
+        "toc": toc,
+        "toc-title": toctitle
         }
     EVENT_LOOP.create_task(send_message_to_all_js_clients(message))
 
@@ -629,8 +630,14 @@ async def md2htmlblocks(content, cwd):
     except KeyError:
         toc = False
 
+    try:
+        toctitle = jsonout['meta']['toc-title']['c'][0]['c']
+    except (IndexError, KeyError):
+        toctitle = None
+
     return (titleblock + htmlblocks,
             supbib,
             refsectit,
             bibid,
-            toc)
+            toc,
+            toctitle)


### PR DESCRIPTION
This adds a button "Contents" to the top-right corner of the document. When clicked, a table of contents is shown based on the headings in the document.

E.g.
```
# One
## One.Two
# Two
```
becomes
```
1. One
1.2. One.Two
2. Two
```

There is one thing I'm not sure about: If a level is "skipped" in the markdown, e.g.
```
# One
### One.?.Three
```
this is currently rendered as
```
1. One
1.1. missing
1.1.1 One.?.Three
```
(with _missing_ in italics). But I guess there are also other possibilities. I chose this for now mainly because it makes the code simple.