### PR TITLE
Use pandoc 2.11's new --citeproc

### DIFF
--- a/client/pmpm.css
+++ b/client/pmpm.css
@@ -452,7 +452,7 @@ div#status {
     transition: background-color .400s linear;
 }
 
-/* Not found citations */
+/* Not found citations, only pandoc version < 2.11 */
 .citeproc-not-found {
     color: #ad0625;
 }

--- a/client/pmpm.js
+++ b/client/pmpm.js
@@ -398,8 +398,12 @@ function updateRefsFromCiteprocResult()
             const citeprocCitation = citeprocCitations[i-1];
             const textciteCache = _textcitesCache[textcite];
 
+            // For pandoc version < 2.11:
             // Not-found citations are displayed as "???" by default, replace with citekey
             // Must be done before html compare
+            // For pandoc version >= 2.11:
+            // This doesn't work because not-found citations don't have "citeproc-not-found" class.
+            // But: Not-found citations already contain the citekey anyway.
             for(const missing of citeprocCitation.getElementsByClassName('citeproc-not-found'))
                 missing.textContent = missing.getAttribute('data-reference-id');
 

--- a/client/pmpm.js
+++ b/client/pmpm.js
@@ -404,6 +404,10 @@ function updateRefsFromCiteprocResult()
             // For pandoc version >= 2.11:
             // This doesn't work because not-found citations don't have "citeproc-not-found" class.
             // But: Not-found citations already contain the citekey anyway.
+            // Note: For pandoc version >= 2.11 the following for loop is redundant,
+            // yet should have no noticeable effect on performance;
+            // if performance should be a problem in the future: have the server send along
+            // a flag indicating whether the client is required to replace  not-found citation keys
             for(const missing of citeprocCitation.getElementsByClassName('citeproc-not-found'))
                 missing.textContent = missing.getAttribute('data-reference-id');
 

--- a/pmpm/websocket.py
+++ b/pmpm/websocket.py
@@ -92,6 +92,7 @@ PIPE_LOST = asyncio.Event()
 
 PANDOC_CALLS = {}
 
+
 def read_socket_activation_fds():
     try:
         import systemd.daemon as sd
@@ -499,7 +500,7 @@ urlRegex = re.compile('(href|src)=[\'"](?!/|https://|http://|#)(.*)[\'"]')
 
 def json2htmlblock_sub(jsontxt, cwd, options):
     proc = subprocess.Popen(
-        PANDOC_CALLS["json2htmlblock"]+options,
+        PANDOC_CALLS["json2htmlblock"] + options,
         cwd=cwd,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,


### PR DESCRIPTION
Pandoc 2.11 has a new internal citeproc version which must be called with `--citeproc` instead of `--filter pandoc-citeproc`. Using `--filter pandoc-citeproc` is deprecated and has worse performance. Thus, we should use `--citeproc` when available.

See https://github.com/jgm/pandoc/releases/tag/2.11

This commit checks if `--citeproc` can be used and, if so, uses it instead of `--filter pandoc-citeproc`.